### PR TITLE
Add :global mode

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,7 @@
+[
+  inputs: [
+    "lib/**/*.{ex,exs}",
+    "test/**/*.{ex,exs}",
+    "mix.exs"
+  ]
+]

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule Mox.MixProject do
       app: :mox,
       version: @version,
       elixir: "~> 1.4",
-      start_permanent: Mix.env == :prod,
+      start_permanent: Mix.env() == :prod,
       name: "Mox",
       description: "Mocks and explicit contracts for Elixir",
       deps: deps(),

--- a/test/mox_test.exs
+++ b/test/mox_test.exs
@@ -9,24 +9,33 @@ defmodule MoxTest do
     @callback mult(integer(), integer()) :: integer()
   end
 
-  defmock CalcMock, for: Calculator
+  defmock(CalcMock, for: Calculator)
+
+  def in_all_modes(callback) do
+    set_mox_global!()
+    callback.()
+    set_mox_private!()
+    callback.()
+  end
 
   describe "defmock/2" do
     test "raises for unknown module" do
       assert_raise ArgumentError, ~r"module Unknown is not available", fn ->
-        defmock MyMock, for: Unknown
+        defmock(MyMock, for: Unknown)
       end
     end
 
     test "raises for non behaviour" do
       assert_raise ArgumentError, ~r"module String is not a behaviour", fn ->
-        defmock MyMock, for: String
+        defmock(MyMock, for: String)
       end
     end
   end
 
   describe "expect/4" do
-    test "is invoked n times" do
+    test "is invoked n times by the same process in private mode" do
+      set_mox_private!()
+
       CalcMock
       |> expect(:add, 2, fn x, y -> x + y end)
       |> expect(:mult, fn x, y -> x * y end)
@@ -34,6 +43,26 @@ defmodule MoxTest do
 
       assert CalcMock.add(2, 3) == 5
       assert CalcMock.add(3, 2) == 5
+      assert CalcMock.add(:whatever, :whatever) == 0
+      assert CalcMock.mult(3, 2) == 6
+    end
+
+    test "is invoked n times by any process in global mode" do
+      set_mox_global!()
+
+      CalcMock
+      |> expect(:add, 2, fn x, y -> x + y end)
+      |> expect(:mult, fn x, y -> x * y end)
+      |> expect(:add, fn _, _ -> 0 end)
+
+      task =
+        Task.async(fn ->
+          assert CalcMock.add(2, 3) == 5
+          assert CalcMock.add(3, 2) == 5
+        end)
+
+      Task.await(task)
+
       assert CalcMock.add(:whatever, :whatever) == 0
       assert CalcMock.mult(3, 2) == 6
     end
@@ -83,14 +112,18 @@ defmodule MoxTest do
       expect(CalcMock, :add, fn x, y -> x + y end)
       assert CalcMock.add(2, 3) == 5
 
-      assert_raise Mox.UnexpectedCallError, ~r"expected CalcMock.add/2 to be called 2 times", fn ->
-        CalcMock.add(2, 3) == 5
-      end
+      assert_raise Mox.UnexpectedCallError,
+                   ~r"expected CalcMock.add/2 to be called 2 times",
+                   fn ->
+                     CalcMock.add(2, 3) == 5
+                   end
     end
   end
 
   describe "verify!/0" do
-    test "verifies all mocks for the current process" do
+    test "verifies all mocks for the current process in private mode" do
+      set_mox_private!()
+
       verify!()
       expect(CalcMock, :add, fn x, y -> x + y end)
 
@@ -104,10 +137,35 @@ defmodule MoxTest do
       message = ~r"expected CalcMock.add/2 to be invoked 2 times but it was invoked once"
       assert_raise Mox.VerificationError, message, &verify!/0
     end
+
+    test "verifies all mocks for the current process in global mode" do
+      set_mox_global!()
+
+      verify!()
+      expect(CalcMock, :add, fn x, y -> x + y end)
+
+      message = ~r"expected CalcMock.add/2 to be invoked once but it was invoked 0 times"
+      assert_raise Mox.VerificationError, message, &verify!/0
+
+      task =
+        Task.async(fn ->
+          assert CalcMock.add(2, 3) == 5
+        end)
+
+      Task.await(task)
+
+      verify!()
+      expect(CalcMock, :add, fn x, y -> x + y end)
+
+      message = ~r"expected CalcMock.add/2 to be invoked 2 times but it was invoked once"
+      assert_raise Mox.VerificationError, message, &verify!/0
+    end
   end
 
   describe "verify!/1" do
-    test "verifies all mocks for the current process" do
+    test "verifies all mocks for the current process in private mode" do
+      set_mox_private!()
+
       verify!(CalcMock)
       expect(CalcMock, :add, fn x, y -> x + y end)
 
@@ -115,6 +173,29 @@ defmodule MoxTest do
       assert_raise Mox.VerificationError, message, &verify!/0
 
       assert CalcMock.add(2, 3) == 5
+      verify!(CalcMock)
+      expect(CalcMock, :add, fn x, y -> x + y end)
+
+      message = ~r"expected CalcMock.add/2 to be invoked 2 times but it was invoked once"
+      assert_raise Mox.VerificationError, message, &verify!/0
+    end
+
+    test "verifies all mocks for current process in global mode" do
+      set_mox_global!()
+
+      verify!(CalcMock)
+      expect(CalcMock, :add, fn x, y -> x + y end)
+
+      message = ~r"expected CalcMock.add/2 to be invoked once but it was invoked 0 times"
+      assert_raise Mox.VerificationError, message, &verify!/0
+
+      task =
+        Task.async(fn ->
+          assert CalcMock.add(2, 3) == 5
+        end)
+
+      Task.await(task)
+
       verify!(CalcMock)
       expect(CalcMock, :add, fn x, y -> x + y end)
 
@@ -136,81 +217,136 @@ defmodule MoxTest do
   describe "verify_on_exit!/0" do
     setup :verify_on_exit!
 
-    test "verifies all mocks even if none is used" do
+    test "verifies all mocks even if none is used in private mode" do
+      set_mox_private!()
       :ok
     end
 
-    test "verifies all mocks for the current process on exit" do
+    test "verifies all mocks for the current process on exit in private mode" do
+      set_mox_private!()
+
       expect(CalcMock, :add, fn x, y -> x + y end)
       assert CalcMock.add(2, 3) == 5
     end
 
-    test "verifies all mocks for the current process on exit with previous verification" do
+    test "verifies all mocks for the current process on exit with previous verification in private mode" do
+      set_mox_private!()
+
       verify!()
       expect(CalcMock, :add, fn x, y -> x + y end)
       assert CalcMock.add(2, 3) == 5
+    end
+
+    test "verifies all mocks even if none is used in global mode" do
+      set_mox_global!()
+      :ok
+    end
+
+    test "verifies all mocks for current process on exit in global mode" do
+      set_mox_global!()
+
+      expect(CalcMock, :add, fn x, y -> x + y end)
+
+      task =
+        Task.async(fn ->
+          assert CalcMock.add(2, 3) == 5
+        end)
+
+      Task.await(task)
+    end
+
+    test "verifies all mocks for the current process on exit with previous verification in global mode" do
+      set_mox_global!()
+
+      verify!()
+      expect(CalcMock, :add, fn x, y -> x + y end)
+
+      task =
+        Task.async(fn ->
+          assert CalcMock.add(2, 3) == 5
+        end)
+
+      Task.await(task)
     end
   end
 
   describe "stub/3" do
     test "allows repeated invocations" do
-      stub(CalcMock, :add, fn x, y -> x + y end)
-      assert CalcMock.add(1, 2) == 3
-      assert CalcMock.add(3, 4) == 7
+      in_all_modes(fn ->
+        stub(CalcMock, :add, fn x, y -> x + y end)
+        assert CalcMock.add(1, 2) == 3
+        assert CalcMock.add(3, 4) == 7
+      end)
     end
 
     test "does not fail verification if not called" do
-      stub(CalcMock, :add, fn x, y -> x + y end)
-      verify!()
+      in_all_modes(fn ->
+        stub(CalcMock, :add, fn x, y -> x + y end)
+        verify!()
+      end)
     end
 
     test "gives expected calls precedence" do
-      CalcMock
-      |> stub(:add, fn x, y -> x + y end)
-      |> expect(:add, fn _, _ -> :expected end)
-      assert CalcMock.add(1, 1) == :expected
-      verify!()
+      in_all_modes(fn ->
+        CalcMock
+        |> stub(:add, fn x, y -> x + y end)
+        |> expect(:add, fn _, _ -> :expected end)
+
+        assert CalcMock.add(1, 1) == :expected
+        verify!()
+      end)
     end
 
     test "invokes stub after expectations are fulfilled" do
-      CalcMock
-      |> stub(:add, fn _x, _y -> :stub end)
-      |> expect(:add, 2, fn _, _ -> :expected end)
-      assert CalcMock.add(1, 1) == :expected
-      assert CalcMock.add(1, 1) == :expected
-      assert CalcMock.add(1, 1) == :stub
-      verify!()
+      in_all_modes(fn ->
+        CalcMock
+        |> stub(:add, fn _x, _y -> :stub end)
+        |> expect(:add, 2, fn _, _ -> :expected end)
+
+        assert CalcMock.add(1, 1) == :expected
+        assert CalcMock.add(1, 1) == :expected
+        assert CalcMock.add(1, 1) == :stub
+        verify!()
+      end)
     end
 
     test "overwrites earlier stubs" do
-      CalcMock
-      |> stub(:add, fn x, y -> x + y end)
-      |> stub(:add, fn _x, _y -> 42 end)
-      assert CalcMock.add(1, 1) == 42
+      in_all_modes(fn ->
+        CalcMock
+        |> stub(:add, fn x, y -> x + y end)
+        |> stub(:add, fn _x, _y -> 42 end)
+
+        assert CalcMock.add(1, 1) == 42
+      end)
     end
 
     test "raises if a non-mock is given" do
-      assert_raise ArgumentError, ~r"module Unknown is not available", fn ->
-        stub(Unknown, :add, fn x, y -> x + y end)
-      end
+      in_all_modes(fn ->
+        assert_raise ArgumentError, ~r"module Unknown is not available", fn ->
+          stub(Unknown, :add, fn x, y -> x + y end)
+        end
 
-      assert_raise ArgumentError, ~r"module String is not a mock", fn ->
-        stub(String, :add, fn x, y -> x + y end)
-      end
+        assert_raise ArgumentError, ~r"module String is not a mock", fn ->
+          stub(String, :add, fn x, y -> x + y end)
+        end
+      end)
     end
 
     test "raises if function is not in behaviour" do
-      assert_raise ArgumentError, ~r"unknown function oops/2 for mock CalcMock", fn ->
-        stub(CalcMock, :oops, fn x, y -> x + y end)
-      end
+      in_all_modes(fn ->
+        assert_raise ArgumentError, ~r"unknown function oops/2 for mock CalcMock", fn ->
+          stub(CalcMock, :oops, fn x, y -> x + y end)
+        end
 
-      assert_raise ArgumentError, ~r"unknown function add/3 for mock CalcMock", fn ->
-        stub(CalcMock, :add, fn x, y, z -> x + y + z end)
-      end
+        assert_raise ArgumentError, ~r"unknown function add/3 for mock CalcMock", fn ->
+          stub(CalcMock, :add, fn x, y, z -> x + y + z end)
+        end
+      end)
     end
   end
 
   describe "allow/3" do
+    setup :set_mox_private!
     setup :verify_on_exit!
 
     test "allows different processes to share mocks from parent process" do
@@ -255,7 +391,8 @@ defmodule MoxTest do
 
         assert CalcMock.add(1, 1) == :expected
         assert CalcMock.mult(1, 1) == :stubbed
-      end) |> Task.await()
+      end)
+      |> Task.await()
     end
 
     test "allowances are transitive" do
@@ -264,6 +401,7 @@ defmodule MoxTest do
       {:ok, child_pid} =
         Task.start_link(fn ->
           assert_raise Mox.UnexpectedCallError, fn -> CalcMock.add(1, 1) end
+
           receive do
             :call_mock ->
               add_result = CalcMock.add(1, 1)
@@ -278,6 +416,7 @@ defmodule MoxTest do
             :allow_mock ->
               CalcMock
               |> allow(self(), child_pid)
+
               send(child_pid, :call_mock)
           end
         end)
@@ -382,6 +521,19 @@ defmodule MoxTest do
         CalcMock
         |> expect(:add, fn _, _ -> :expected end)
       end
+    end
+
+    test "raises if you try to allow process while in global mode" do
+      set_mox_global!()
+      {:ok, child_pid} = Task.start_link(fn -> Process.sleep(:infinity) end)
+
+      Task.async(fn ->
+        assert_raise ArgumentError, ~r"already has access to all defined expectations", fn ->
+          CalcMock
+          |> allow(self(), child_pid)
+        end
+      end)
+      |> Task.await()
     end
   end
 end


### PR DESCRIPTION
So yeah, I made a few circles with this back and forth. My quick'n'dirty initial implementation was quite similar to this one, then decided we need 2 separate servers for global and private modes, but in the end I did like the original version more. Just made some tweaks to it.

So the general idea is that we have 2 modes (so far): private and global.

In private mode the only process who can declare expectations, stubs, and also consume them and verify is the same process. In private mode tests can run in async mode.

In global mode tests no longer can run in async mode. The same process which declares expectations, needs to verify them, but any process can consume them.

Private is the default mode. You can switch to global mode with `set_mox_global!` in your `setup` block.

You can also set appropriate mode based on the value of async tag:

    setup :set_mox_from_context!

in such case defaults to private for `async: true` tests, global otherwise.