### PR TITLE
Support mocking multiple behaviours

### DIFF
--- a/lib/mox.ex
+++ b/lib/mox.ex
@@ -62,6 +62,18 @@ defmodule Mox do
   All expectations are defined based on the current process. This
   means multiple tests using the same mock can still run concurrently.
 
+  Mox supports defining a mock for multiple behaviours.
+
+  Suppose your library also defines a scientific calculator behaviour:
+
+      defmodule MyApp.ScientificCalculator do
+        @callback exponent(integer(), integer()) :: integer()
+      end
+
+  You can mock both the calculator and scientific calculator behaviour:
+
+      Mox.defmock(MyApp.SciCalcMock, for: [MyApp.Calculator, MyApp.ScientificCalculator])
+
   ## Compile-time requirements
 
   If the mock needs to be available during the project compilation, for
@@ -188,9 +200,13 @@ defmodule Mox do
   def set_mox_from_context(_context), do: set_mox_global()
 
   @doc """
-  Defines a mock with the given name `:for` the given behaviour.
+  Defines a mock with the given name `:for` the given behaviour(s).
 
       Mox.defmock MyMock, for: MyBehaviour
+
+  With multiple behaviours:
+
+      Mox.defmock MyMock, for: [MyBehaviour, MyOtherBehaviour]
 
   """
   def defmock(name, options) when is_atom(name) and is_list(options) do

--- a/lib/mox.ex
+++ b/lib/mox.ex
@@ -62,7 +62,7 @@ defmodule Mox do
   All expectations are defined based on the current process. This
   means multiple tests using the same mock can still run concurrently.
 
-  Mox supports defining a mock for multiple behaviours.
+  Mox supports defining mocks for multiple behaviours.
 
   Suppose your library also defines a scientific calculator behaviour:
 

--- a/test/mox_test.exs
+++ b/test/mox_test.exs
@@ -13,7 +13,7 @@ defmodule MoxTest do
     @callback exponent(integer(), integer()) :: integer()
   end
 
-  defmock(CalcMock, for: [Calculator])
+  defmock(CalcMock, for: Calculator)
   defmock(SciCalcMock, for: [Calculator, ScientificCalculator])
 
   def in_all_modes(callback) do
@@ -26,13 +26,13 @@ defmodule MoxTest do
   describe "defmock/2" do
     test "raises for unknown module" do
       assert_raise ArgumentError, ~r"module Unknown is not available", fn ->
-        defmock(MyMock, for: [Unknown])
+        defmock(MyMock, for: Unknown)
       end
     end
 
     test "raises for non behaviour" do
       assert_raise ArgumentError, ~r"module String is not a behaviour", fn ->
-        defmock(MyMock, for: [String])
+        defmock(MyMock, for: String)
       end
     end
 

--- a/test/mox_test.exs
+++ b/test/mox_test.exs
@@ -42,7 +42,7 @@ defmodule MoxTest do
   end
 
   describe "expect/4" do
-    test "works on multiple behaviours" do
+    test "works with multiple behaviours" do
       SciCalcMock
       |> expect(:exponent, fn x, y -> :math.pow(x, y) end)
       |> expect(:add, fn x, y -> x + y end)
@@ -374,6 +374,17 @@ defmodule MoxTest do
         assert CalcMock.add(1, 1) == 42
       end)
     end
+
+    test "works with multiple behaviours" do
+      in_all_modes(fn ->
+        SciCalcMock
+        |> stub(:add, fn x, y -> x + y end)
+        |> stub(:exponent, fn x, y -> :math.pow(x, y) end) 
+
+        assert SciCalcMock.add(1, 1) == 2
+        assert SciCalcMock.exponent(2, 3) == 8 
+      end)
+    end 
 
     test "raises if a non-mock is given" do
       in_all_modes(fn ->


### PR DESCRIPTION
Fixes https://github.com/plataformatec/mox/issues/26

This is **super** rough and needs to be cleaned up.

I wanted to ask if we should support a single behaviour (not in a list), for example:

`Mox.defmock(MyMock, for: Calculator)`

or

`Mox.defmock(MyMock, for: [Calculator])`

I'm leading towards supporting both. Thoughts?