### PR TITLE
Adds stub_with function for stubbing a mock with module.

### DIFF
--- a/lib/mox.ex
+++ b/lib/mox.ex
@@ -357,6 +357,7 @@ defmodule Mox do
         stub(mock, fun, from_mfa(module, fun, arity))
       end
     end
+    mock
   end
 
   defp from_mfa(m, f, a) do

--- a/test/mox_test.exs
+++ b/test/mox_test.exs
@@ -13,11 +13,6 @@ defmodule MoxTest do
     @callback exponent(integer(), integer()) :: integer()
   end
 
-  defmodule CalculatorImplementation do
-    def add(a, b), do: a + b
-    def mult(a, b), do: a * b
-  end
-
   defmock(CalcMock, for: Calculator)
   defmock(SciCalcMock, for: [Calculator, ScientificCalculator])
 
@@ -417,13 +412,50 @@ defmodule MoxTest do
   end
 
   describe "stub_with/2" do
+
+    defmodule CalcImplementation do
+      @behaviour Calculator
+      def add(x, y), do: x + y
+      def mult(x, y), do: x * y
+    end
+
+    defmodule SciCalcImplementation do
+      @behaviour Calculator
+      def add(x, y), do: x + y
+      def mult(x, y), do: x * y
+
+      @behaviour ScientificCalculator
+      def exponent(x, y), do: :math.pow(x, y)
+    end
+
     test "stubs all functions with functions from a module" do
       in_all_modes(fn ->
-        stub_with(CalcMock, CalculatorImplementation)
+        stub_with(CalcMock, CalcImplementation)
         assert CalcMock.add(1, 2) == 3
         assert CalcMock.add(3, 4) == 7
         assert CalcMock.mult(2, 2) == 4
         assert CalcMock.mult(3, 4) == 12
+      end)
+    end
+
+    test "Leaves behaviours not implemented by the module un-stubbed" do
+      in_all_modes(fn ->
+        stub_with(SciCalcMock, CalcImplementation)
+        assert SciCalcMock.add(1, 2) == 3
+        assert SciCalcMock.mult(3, 4) == 12
+
+        assert_raise Mox.UnexpectedCallError, fn ->
+          SciCalcMock.exponent(2, 10)
+        end
+      end)
+    end
+
+    test "can stub multiple behaviours from a single module" do
+      in_all_modes(fn ->
+        stub_with(SciCalcMock, SciCalcImplementation)
+        assert SciCalcMock.add(1, 2) == 3
+        assert SciCalcMock.mult(3, 4) == 12
+        assert SciCalcMock.exponent(2, 10) == 1024
       end)
     end
   end

--- a/test/mox_test.exs
+++ b/test/mox_test.exs
@@ -13,6 +13,11 @@ defmodule MoxTest do
     @callback exponent(integer(), integer()) :: integer()
   end
 
+  defmodule CalculatorImplementation do
+    def add(a, b), do: a + b
+    def mult(a, b), do: a * b
+  end
+
   defmock(CalcMock, for: Calculator)
   defmock(SciCalcMock, for: [Calculator, ScientificCalculator])
 
@@ -407,6 +412,18 @@ defmodule MoxTest do
         assert_raise ArgumentError, ~r"unknown function add/3 for mock CalcMock", fn ->
           stub(CalcMock, :add, fn x, y, z -> x + y + z end)
         end
+      end)
+    end
+  end
+
+  describe "stub_with/2" do
+    test "stubs all functions with functions from a module" do
+      in_all_modes(fn ->
+        stub_with(CalcMock, CalculatorImplementation)
+        assert CalcMock.add(1, 2) == 3
+        assert CalcMock.add(3, 4) == 7
+        assert CalcMock.mult(2, 2) == 4
+        assert CalcMock.mult(3, 4) == 12
       end)
     end
   end

--- a/test/mox_test.exs
+++ b/test/mox_test.exs
@@ -428,6 +428,15 @@ defmodule MoxTest do
       def exponent(x, y), do: :math.pow(x, y)
     end
 
+    test "can override stubs" do
+      in_all_modes(fn ->
+        stub_with(CalcMock, CalcImplementation)
+        |> expect(:add, fn 1, 2 -> 4 end)
+        assert CalcMock.add(1, 2) == 4
+        verify!()
+      end)
+    end
+
     test "stubs all functions with functions from a module" do
       in_all_modes(fn ->
         stub_with(CalcMock, CalcImplementation)


### PR DESCRIPTION
When using Mox it can be hard, once we're using a mock in the test environment, to replace the mock with the "real" implementation in order to do any type of integration testing. For example, say we have an umbrella app with a `storage` app and a `web` app. `web` provides a web interface and communicates to `storage` via a defined behaviour to access the data layer. In order to unit test `web` we use Mox to replace `Storage` with `MockStorage`. But we also want to have a few integration tests that verify the integration of these two apps. The problem is that once `MockStorage` is in place we can't switch back to `Storage`. We need a way to stub `MockStorage` and tell it "act just like the real `Storage` in this test", without having to explicitly stub every function in the behaviour like this:

```elixir
MockStorage 
|> stub(:fun1, &Storage.fun1/2)
|> stub(:fun1, &Storage.fun1/3)
|> stub(:fun2, &Storage.fun2/1)
#etc...
```

This pr adds a `stub_with/2` function to `Mox` that provides that behaviour, allowing us to just say:

```elixir
MockStorage |> stub_with(Storage)
```

`stub_with` finds all of the behaviours `MockStroage` and `Stroage` have in common and stubs all of those functions with the implementations from `Stroage`.