### PR TITLE
Allow expect/4 to assert function not called

### DIFF
--- a/lib/mox.ex
+++ b/lib/mox.ex
@@ -287,12 +287,16 @@ defmodule Mox do
 
       expect(MyMock, :add, 5, fn x, y -> x + y end)
 
+  To expect `MyMock.add/2` to not be called:
+
+      expect(MyMock, :add, 0, fn x, y -> :ok end)
+
   `expect/4` can also be invoked multiple times for the same
   name/arity, allowing you to give different behaviours on each
   invocation.
   """
   def expect(mock, name, n \\ 1, code)
-      when is_atom(mock) and is_atom(name) and is_integer(n) and n >= 1 and is_function(code) do
+      when is_atom(mock) and is_atom(name) and is_integer(n) and n >= 0 and is_function(code) do
     calls = List.duplicate(code, n)
     add_expectation!(mock, name, code, {n, calls, nil})
     mock

--- a/test/mox_test.exs
+++ b/test/mox_test.exs
@@ -85,6 +85,16 @@ defmodule MoxTest do
       assert CalcMock.mult(3, 2) == 6
     end
 
+    test "allows asserting that function is not called" do
+      CalcMock
+      |> expect(:add, 0, fn x, y -> x + y end)
+
+      msg = ~r"expected CalcMock.add/2 to be called 0 times but it has been called once"
+      assert_raise Mox.UnexpectedCallError, msg, fn ->
+        CalcMock.add(2, 3) == 5
+      end
+    end
+
     test "can be recharged" do
       expect(CalcMock, :add, fn x, y -> x + y end)
       assert CalcMock.add(2, 3) == 5


### PR DESCRIPTION
Change guard clause for `expect/4` to verify that `n>=0`. This allows `expect` to explicitly assert that a function was not called. Addresses #32.