### PR TITLE
Creating an allowance in global mode is now ignored

### DIFF
--- a/lib/mox.ex
+++ b/lib/mox.ex
@@ -464,11 +464,8 @@ defmodule Mox do
         """
 
       {:error, :in_global_mode} ->
-        raise ArgumentError, """
-        cannot allow #{inspect(allowed_pid)} to use #{inspect(mock)} from #{inspect(owner_pid)} \
-        because Mox is in global mode, the process already has access to all \
-        defined expectations/stubs
-        """
+        # Already allowed
+        mock
     end
   end
 

--- a/test/mox_test.exs
+++ b/test/mox_test.exs
@@ -715,15 +715,13 @@ defmodule MoxTest do
       end
     end
 
-    test "raises if you try to allow process while in global mode" do
+    test "is ignored if you allow process while in global mode" do
       set_mox_global()
       {:ok, child_pid} = Task.start_link(fn -> Process.sleep(:infinity) end)
 
       Task.async(fn ->
-        assert_raise ArgumentError, ~r"already has access to all defined expectations", fn ->
-          CalcMock
-          |> allow(self(), child_pid)
-        end
+        mock = CalcMock
+        assert allow(mock, self(), child_pid) == mock
       end)
       |> Task.await()
     end


### PR DESCRIPTION
This can be useful if you create a shim to assist in testing. Now you can use your shim all of the time without having to know if Mox is in global mode or not.

Fixes #46