### PR TITLE
Use $callers to use expectations made in the calling process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ matrix:
   include:
     - elixir: 1.5.2
       otp_release: 20.0
+  include:
+    - elixir: 1.8.1
+      otp_release: 21.2
 notifications:
   recipients:
     - jose.valim@plataformatec.com.br

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,9 @@
 language: elixir
 sudo: false
-elixir: 1.4.1
-otp_release: 19.1
 matrix:
   include:
     - elixir: 1.5.2
       otp_release: 20.0
-  include:
     - elixir: 1.8.1
       otp_release: 21.2
 notifications:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog for 0.5
+
+## unreleased
+
+### 1. Enhancements
+
+* When on Elixir 1.8 use `$callers` to automatically use expectations defined in the calling process

--- a/lib/mox.ex
+++ b/lib/mox.ex
@@ -537,7 +537,7 @@ defmodule Mox do
 
   @doc false
   def __dispatch__(mock, name, arity, args) do
-    case Mox.Server.fetch_fun_to_dispatch(self(), {mock, name, arity}) do
+    case Mox.Server.fetch_fun_to_dispatch(caller_pid(), {mock, name, arity}) do
       :no_expectation ->
         mfa = Exception.format_mfa(mock, name, arity)
 
@@ -558,4 +558,12 @@ defmodule Mox do
 
   defp times(1), do: "once"
   defp times(n), do: "#{n} times"
+
+  # Find the pid of the actual caller
+  defp caller_pid do
+    case Process.get(:"$callers") do
+      nil -> self()
+      pids when is_list(pids) -> List.last(pids)
+    end
+  end
 end

--- a/lib/mox.ex
+++ b/lib/mox.ex
@@ -542,7 +542,9 @@ defmodule Mox do
 
   @doc false
   def __dispatch__(mock, name, arity, args) do
-    case Mox.Server.fetch_fun_to_dispatch(caller_pid(), {mock, name, arity}) do
+    all_callers = [self() | caller_pids()]
+
+    case Mox.Server.fetch_fun_to_dispatch(all_callers, {mock, name, arity}) do
       :no_expectation ->
         mfa = Exception.format_mfa(mock, name, arity)
 
@@ -565,10 +567,10 @@ defmodule Mox do
   defp times(n), do: "#{n} times"
 
   # Find the pid of the actual caller
-  defp caller_pid do
+  defp caller_pids do
     case Process.get(:"$callers") do
-      nil -> self()
-      pids when is_list(pids) -> List.last(pids)
+      nil -> [self()]
+      pids when is_list(pids) -> [self() | pids]
     end
   end
 end

--- a/lib/mox.ex
+++ b/lib/mox.ex
@@ -549,14 +549,14 @@ defmodule Mox do
         mfa = Exception.format_mfa(mock, name, arity)
 
         raise UnexpectedCallError,
-              "no expectation defined for #{mfa} in process #{inspect(self())}"
+              "no expectation defined for #{mfa} in #{format_process()}"
 
       {:out_of_expectations, count} ->
         mfa = Exception.format_mfa(mock, name, arity)
 
         raise UnexpectedCallError,
               "expected #{mfa} to be called #{times(count)} but it has been " <>
-                "called #{times(count + 1)} in process #{inspect(self())}"
+                "called #{times(count + 1)} in process #{format_process()}"
 
       {:ok, fun_to_call} ->
         apply(fun_to_call, args)
@@ -566,11 +566,22 @@ defmodule Mox do
   defp times(1), do: "once"
   defp times(n), do: "#{n} times"
 
+  defp format_process do
+    callers = caller_pids()
+
+    "process #{inspect(self())}" <>
+      if Enum.empty?(callers) do
+        ""
+      else
+        " (or in its callers #{inspect callers})"
+      end
+  end
+
   # Find the pid of the actual caller
   defp caller_pids do
     case Process.get(:"$callers") do
-      nil -> [self()]
-      pids when is_list(pids) -> [self() | pids]
+      nil -> []
+      pids when is_list(pids) -> pids
     end
   end
 end

--- a/lib/mox.ex
+++ b/lib/mox.ex
@@ -132,6 +132,11 @@ defmodule Mox do
         |> Task.await
       end
 
+  Note: if you're running on Elixir 1.8.0 or greater and your concurrency comes
+  from a `Task` then you don't need to add explicit allowances. Instead
+  `$callers` is used to determine the process that actually defined the
+  expectations.
+
   ### Global mode
 
   Mox supports global mode, where any process can consume mocks and stubs

--- a/lib/mox/server.ex
+++ b/lib/mox/server.ex
@@ -85,18 +85,14 @@ defmodule Mox.Server do
         _from,
         %{mode: :private} = state
       ) do
-    owner_pid = Enum.find_value(caller_pids, List.first(caller_pids), fn caller_pid ->
-      cond do
-        state.allowances[caller_pid][mock] ->
-          state.allowances[caller_pid][mock]
-
-        state.expectations[caller_pid][key] ->
-          caller_pid
-
-        true ->
-          false
-      end
-    end)
+    owner_pid =
+      Enum.find_value(caller_pids, List.first(caller_pids), fn caller_pid ->
+        cond do
+          state.allowances[caller_pid][mock] -> state.allowances[caller_pid][mock]
+          state.expectations[caller_pid][key] -> caller_pid
+          true -> false
+        end
+      end)
 
     case state.expectations[owner_pid][key] do
       nil ->

--- a/test/mox_test.exs
+++ b/test/mox_test.exs
@@ -91,49 +91,51 @@ defmodule MoxTest do
       assert CalcMock.mult(3, 2) == 6
     end
 
-    # TODO: Only run this test on Elixir 1.8
     test "is invoked n times by any process in private mode on Elixir 1.8" do
-      set_mox_private()
+      if caller_tracking_supported?() do
+        set_mox_private()
 
-      CalcMock
-      |> expect(:add, 2, fn x, y -> x + y end)
-      |> expect(:mult, fn x, y -> x * y end)
-      |> expect(:add, fn _, _ -> 0 end)
+        CalcMock
+        |> expect(:add, 2, fn x, y -> x + y end)
+        |> expect(:mult, fn x, y -> x * y end)
+        |> expect(:add, fn _, _ -> 0 end)
 
-      task =
-        Task.async(fn ->
-          assert CalcMock.add(2, 3) == 5
-          assert CalcMock.add(3, 2) == 5
-        end)
-
-      Task.await(task)
-
-      assert CalcMock.add(:whatever, :whatever) == 0
-      assert CalcMock.mult(3, 2) == 6
-    end
-
-    # TODO: Only run this test on Elixir 1.8
-    test "is invoked n times by a sub-process in private mode on Elixir 1.8" do
-      set_mox_private()
-
-      CalcMock
-      |> expect(:add, 2, fn x, y -> x + y end)
-      |> expect(:mult, fn x, y -> x * y end)
-      |> expect(:add, fn _, _ -> 0 end)
-
-      task =
-        Task.async(fn ->
-          assert CalcMock.add(2, 3) == 5
-          assert CalcMock.add(3, 2) == 5
-          inner_task = Task.async(fn ->
-            assert CalcMock.add(:whatever, :whatever) == 0
-            assert CalcMock.mult(3, 2) == 6
+        task =
+          Task.async(fn ->
+            assert CalcMock.add(2, 3) == 5
+            assert CalcMock.add(3, 2) == 5
           end)
 
-          Task.await(inner_task)
-        end)
+        Task.await(task)
 
-      Task.await(task)
+        assert CalcMock.add(:whatever, :whatever) == 0
+        assert CalcMock.mult(3, 2) == 6
+      end
+    end
+
+    test "is invoked n times by a sub-process in private mode on Elixir 1.8" do
+      if caller_tracking_supported?() do
+        set_mox_private()
+
+        CalcMock
+        |> expect(:add, 2, fn x, y -> x + y end)
+        |> expect(:mult, fn x, y -> x * y end)
+        |> expect(:add, fn _, _ -> 0 end)
+
+        task =
+          Task.async(fn ->
+            assert CalcMock.add(2, 3) == 5
+            assert CalcMock.add(3, 2) == 5
+            inner_task = Task.async(fn ->
+              assert CalcMock.add(:whatever, :whatever) == 0
+              assert CalcMock.mult(3, 2) == 6
+            end)
+
+            Task.await(inner_task)
+          end)
+
+        Task.await(task)
+      end
     end
 
     test "allows asserting that function is not called" do
@@ -773,9 +775,19 @@ defmodule MoxTest do
   end
 
   defp assert_default_raise(exception, fun) do
-    # If $callers is defined then we are on Elixir 1.8+ and there is an automatic allowance
-    unless Process.get(:"$callers") do
+    unless caller_tracking_supported?() do
       assert_raise exception, fun
     end
+  end
+
+  defp caller_tracking_supported? do
+    task = Task.async(fn ->
+      case Process.get(:"$callers") do
+        nil -> false
+        [_pid] -> true
+      end
+    end)
+
+    Task.await(task)
   end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,8 @@
-ExUnit.start()
+excludes =
+  if Version.match?(System.version(), ">= 1.8.0") do
+    []
+  else
+    [:requires_caller_tracking]
+  end
+
+ExUnit.start(exclude: excludes)


### PR DESCRIPTION
My first implementation passed the result of `Process.get(:"$callers")` in to the server for processing but it felt cleaner to do that call in `Mox` itself.

Questions:
* How should we stop the new tests from running when Elixir < 1.8?
  * We could do feature detection by spawning a task and checking if it has `$callers` set?
    * I didn't like this initially but I'm coming around to it. We could even use the same function in `assert_default_raise/2`
  * Use an exunit tag and exclude it on some runs?
  * Direct version detection with `System.version/0`
* Should we add a test that uses spawn directly and assert that that still fails?
* Is `$callers` documented anywhere besides the Elixir 1.8 release notes?