### PR TITLE
:skip_optional_callbacks option to `defmock` skips optional callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Enhancements
+
+  * Added `:skip_optional_callbacks` option to `defmock/2` that allows you to optionally skip the definition of optional callbacks.
+
 ## v0.5.0 (2019-02-03)
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Enhancements
 
-  * Added `:skip_optional_callbacks` option to `defmock/2` that allows you to optionally skip the definition of optional callbacks.
+  * Add `:skip_optional_callbacks` option to `defmock/2` that allows you to optionally skip the definition of optional callbacks.
 
 ## v0.5.0 (2019-02-03)
 

--- a/lib/mox.ex
+++ b/lib/mox.ex
@@ -306,9 +306,9 @@ defmodule Mox do
       skip_list when is_list(skip_list) ->
         for callback <- skip_optional_callbacks, callback not in all_optional_callbacks do
           raise ArgumentError,
-            "all entries in :skip_optional_callbacks must be an optional callback in one " <>
-            "of the behaviours specified in :for. #{inspect(callback)} was not in the " <>
-            "list of all optional callbacks: #{inspect(all_optional_callbacks)}"
+                "all entries in :skip_optional_callbacks must be an optional callback in one " <>
+                  "of the behaviours specified in :for. #{inspect(callback)} was not in the " <>
+                  "list of all optional callbacks: #{inspect(all_optional_callbacks)}"
         end
 
         skip_list

--- a/lib/mox.ex
+++ b/lib/mox.ex
@@ -299,9 +299,9 @@ defmodule Mox do
 
     for callback <- skip_optional_callbacks, callback not in all_optional_callbacks do
       raise ArgumentError,
-            "All entries in :skip_optional_callbacks must be an optional callback in one of the behaviours specified in :for. #{
-              inspect(callback)
-            } was not in the list of all optional callbacks: #{inspect(all_optional_callbacks)}"
+            "all entries in :skip_optional_callbacks must be an optional callback in one " <>
+              "of the behaviours specified in :for. #{inspect(callback)} was not in the " <>
+              "list of all optional callbacks: #{inspect(all_optional_callbacks)}"
     end
   end
 

--- a/test/mox_test.exs
+++ b/test/mox_test.exs
@@ -60,15 +60,27 @@ defmodule MoxTest do
       assert all_callbacks -- MyMultiMock.__info__(:functions) == [sin: 1]
     end
 
-    test "raises if :skip_optional_callbacks is not a list" do
-      assert_raise ArgumentError, ":skip_optional_callbacks is required to be a list", fn ->
-        defmock(MyMock, for: Calculator, skip_optional_callbacks: false)
+    test "accepts false to indicate all functions should be generated" do
+      defmock(MyFalseMock, for: [Calculator, ScientificCalculator], skip_optional_callbacks: false)
+      all_callbacks = ScientificCalculator.behaviour_info(:callbacks)
+      assert all_callbacks -- MyFalseMock.__info__(:functions) == []
+    end
+
+    test "accepts true to indicate no optional functions should be generated" do
+      defmock(MyTrueMock, for: [Calculator, ScientificCalculator], skip_optional_callbacks: true)
+      all_callbacks = ScientificCalculator.behaviour_info(:callbacks)
+      assert all_callbacks -- MyTrueMock.__info__(:functions) == [sin: 1]
+    end
+
+    test "raises if :skip_optional_callbacks is not a list or boolean" do
+      assert_raise ArgumentError, ":skip_optional_callbacks is required to be a list or boolean", fn ->
+        defmock(MyMock, for: Calculator, skip_optional_callbacks: 42)
       end
     end
 
     test "raises if a callback in :skip_optional_callbacks does not exist" do
       expected_error =
-        "All entries in :skip_optional_callbacks must be an optional callback in" <>
+        "all entries in :skip_optional_callbacks must be an optional callback in" <>
           " one of the behaviours specified in :for. {:some_other_function, 0} was not in the list" <>
           " of all optional callbacks: []"
 
@@ -82,7 +94,7 @@ defmodule MoxTest do
 
     test "raises if a callback in :skip_optional_callbacks is not an optional callback" do
       expected_error =
-        "All entries in :skip_optional_callbacks must be an optional callback in" <>
+        "all entries in :skip_optional_callbacks must be an optional callback in" <>
         " one of the behaviours specified in :for. {:exponent, 2} was not in the list" <>
         " of all optional callbacks: [sin: 1]"
 

--- a/test/mox_test.exs
+++ b/test/mox_test.exs
@@ -55,13 +55,18 @@ defmodule MoxTest do
     end
 
     test "accepts a list of callbacks to skip" do
-      defmock(MyMultiMock, for: [Calculator, ScientificCalculator], skip_optional_callbacks: [sin: 1])
+      defmock(MyMultiMock,
+        for: [Calculator, ScientificCalculator],
+        skip_optional_callbacks: [sin: 1]
+      )
+
       all_callbacks = ScientificCalculator.behaviour_info(:callbacks)
       assert all_callbacks -- MyMultiMock.__info__(:functions) == [sin: 1]
     end
 
     test "accepts false to indicate all functions should be generated" do
       defmock(MyFalseMock, for: [Calculator, ScientificCalculator], skip_optional_callbacks: false)
+
       all_callbacks = ScientificCalculator.behaviour_info(:callbacks)
       assert all_callbacks -- MyFalseMock.__info__(:functions) == []
     end
@@ -73,9 +78,11 @@ defmodule MoxTest do
     end
 
     test "raises if :skip_optional_callbacks is not a list or boolean" do
-      assert_raise ArgumentError, ":skip_optional_callbacks is required to be a list or boolean", fn ->
-        defmock(MyMock, for: Calculator, skip_optional_callbacks: 42)
-      end
+      assert_raise ArgumentError,
+                   ":skip_optional_callbacks is required to be a list or boolean",
+                   fn ->
+                     defmock(MyMock, for: Calculator, skip_optional_callbacks: 42)
+                   end
     end
 
     test "raises if a callback in :skip_optional_callbacks does not exist" do
@@ -95,8 +102,8 @@ defmodule MoxTest do
     test "raises if a callback in :skip_optional_callbacks is not an optional callback" do
       expected_error =
         "all entries in :skip_optional_callbacks must be an optional callback in" <>
-        " one of the behaviours specified in :for. {:exponent, 2} was not in the list" <>
-        " of all optional callbacks: [sin: 1]"
+          " one of the behaviours specified in :for. {:exponent, 2} was not in the list" <>
+          " of all optional callbacks: [sin: 1]"
 
       assert_raise ArgumentError, expected_error, fn ->
         defmock(MyMock,

--- a/test/mox_test.exs
+++ b/test/mox_test.exs
@@ -11,6 +11,8 @@ defmodule MoxTest do
 
   defmodule ScientificCalculator do
     @callback exponent(integer(), integer()) :: integer()
+    @callback sin(integer()) :: float()
+    @optional_callbacks [sin: 1]
   end
 
   defmock(CalcMock, for: Calculator)
@@ -44,6 +46,52 @@ defmodule MoxTest do
 
     test "accepts a list of behaviours" do
       assert defmock(MyMock, for: [Calculator, ScientificCalculator])
+    end
+
+    test "defines a mock function for all callbacks by default" do
+      defmock(MyScientificMock, for: ScientificCalculator)
+      all_callbacks = ScientificCalculator.behaviour_info(:callbacks)
+      assert all_callbacks -- MyScientificMock.__info__(:functions) == []
+    end
+
+    test "accepts a list of callbacks to skip" do
+      defmock(MyMultiMock, for: [Calculator, ScientificCalculator], skip_optional_callbacks: [sin: 1])
+      all_callbacks = ScientificCalculator.behaviour_info(:callbacks)
+      assert all_callbacks -- MyMultiMock.__info__(:functions) == [sin: 1]
+    end
+
+    test "raises if :skip_optional_callbacks is not a list" do
+      assert_raise ArgumentError, ":skip_optional_callbacks is required to be a list", fn ->
+        defmock(MyMock, for: Calculator, skip_optional_callbacks: false)
+      end
+    end
+
+    test "raises if a callback in :skip_optional_callbacks does not exist" do
+      expected_error =
+        "All entries in :skip_optional_callbacks must be an optional callback in" <>
+          " one of the behaviours specified in :for. {:some_other_function, 0} was not in the list" <>
+          " of all optional callbacks: []"
+
+      assert_raise ArgumentError, expected_error, fn ->
+        defmock(MyMock,
+          for: Calculator,
+          skip_optional_callbacks: [some_other_function: 0]
+        )
+      end
+    end
+
+    test "raises if a callback in :skip_optional_callbacks is not an optional callback" do
+      expected_error =
+        "All entries in :skip_optional_callbacks must be an optional callback in" <>
+        " one of the behaviours specified in :for. {:exponent, 2} was not in the list" <>
+        " of all optional callbacks: [sin: 1]"
+
+      assert_raise ArgumentError, expected_error, fn ->
+        defmock(MyMock,
+          for: ScientificCalculator,
+          skip_optional_callbacks: [exponent: 2]
+        )
+      end
     end
   end
 


### PR DESCRIPTION
This is useful if you have code that checks if a given function is implemented and only calls it in that case (or has completely separate behavior in the not-implemented case). By default all optional callbacks are implemented as functions.

Note: in the tests I didn't name all the defined mocks `MyMock` because I received warnings like:

    warning: redefining module MyMock (current version defined in memory)
      lib/mox.ex:316

Fixes #61 