### PR TITLE
Highlight the utility of stub_with/2

### DIFF
--- a/lib/mox.ex
+++ b/lib/mox.ex
@@ -64,6 +64,18 @@ defmodule Mox do
   unless the Mox is set to global mode. See the "Multi-process collaboration"
   section.
 
+  Especially if you put the mock into the config/application environment you
+  might want the implementation to fall back to the original implementation
+  when no expectations are defined. `stub_with/2` is just what you need! Given
+  that `MyApp.TestCalculator` is the implementation you are mocking you can
+  do the following in `test_helper.exs` after defining the mock with
+  `defmock/2`:
+
+      Mox.stub_with(MyApp.CalcMock, MyApp.TestCalculator)
+
+  Now, if no expectations are defined it will call the implementation in
+  `MyApp.TestCalculator`.
+
   ## Multiple behaviours
 
   Mox supports defining mocks for multiple behaviours.


### PR DESCRIPTION
Thanks for mox and all your other work as usual :green_heart: :pray: :tada: 

I think it's most useful for when we can't pass the mock to the
system under test directly/we have to configure it in the test
environment. Hence I added it right underneath that section.

Not sure if that's the best choice or if a separate section
would be better. Happy for feedback!

Follow up to #76