### PR TITLE
stub_with/2 needs to be called in the process that uses it

### DIFF
--- a/lib/mox.ex
+++ b/lib/mox.ex
@@ -69,8 +69,7 @@ defmodule Mox do
   might want the implementation to fall back to the original implementation
   when no expectations are defined. `stub_with/2` is just what you need! Given
   that `MyApp.TestCalculator` is the implementation you are mocking you can
-  do the following in `test_helper.exs` after defining the mock with
-  `defmock/2`:
+  do the following in your test (for instance inside `setup`):
 
       Mox.stub_with(MyApp.CalcMock, MyApp.TestCalculator)
 


### PR DESCRIPTION
See #41 - I wrote the docs based on my understanding of the other
docs, which turns out was wrong which I realized when finally
implementing it. Sorry.

I'll open another issue to ask about feature/acceptance tests then :)